### PR TITLE
feat: enable scraping ingress metrics

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,14 @@ haproxy-ingress:
         - port: 443
           targetPort: https
           nodePort: 30443
+    stats:
+      enabled: true
+    metrics:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      labels:
+        monitorGroup: default         
     extraArgs:
       watch-ingress-without-class: "true"
     podAnnotations:


### PR DESCRIPTION
This enables the stats and metrics endpoints and adds a `ServiceMonitor` that will be picked up by the Prometheus Operator. The label `monitorGroup` is used to ensure that this `ServiceMonitor` will be picked up by our Prometheus, which has a `labelSelector` for this label.